### PR TITLE
Update log collector DS ready condition to NumberAvailable to ensure DS is running

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -135,7 +135,7 @@ func deployLogCollectors(client *kubernetes.Clientset) error {
 		if err != nil {
 			return err
 		}
-		if ds.Status.CurrentNumberScheduled != ds.Status.DesiredNumberScheduled {
+		if ds.Status.NumberAvailable != ds.Status.DesiredNumberScheduled {
 			time.Sleep(time.Second * 1)
 			continue
 		}


### PR DESCRIPTION

This update makes sure that the log collector daemonset is running before continuing with log collection. It will prevent deleteLogCollectors function from deleting daemonset too soon or starting log collection before container is running. 

Resolves https://github.com/rancher/rancher/issues/16609

```
./system-tools logs
INFO[0000] deploying log collection DaemonSet [log-collector].. 
INFO[0000] wating for DaemonSet [log-collector] to be ready.. 
INFO[0001] log collection DaemonSet [log-collector] deployed successfully.. 
INFO[0001] starting log collection..                    
INFO[0001] fetching logs from node [ip-10-248-128-35.us-west-2.compute.internal].. 
INFO[0012] removing log collection DaemonSet [log-collector].. 
INFO[0012] log collection DaemonSet [log-collector] removed successfully.. 

ls -lh cluster-logs.tar && tar tf cluster-logs.tar 
-rw-r--r--  1 gellis  staff    22M Jan 14 10:47 cluster-logs.tar
ip-10-248-128-35.us-west-2.compute.internal/
ip-10-248-128-35.us-west-2.compute.internal/etcd.log
ip-10-248-128-35.us-west-2.compute.internal/kube-apiserver.log
ip-10-248-128-35.us-west-2.compute.internal/kube-controller-manager.log
ip-10-248-128-35.us-west-2.compute.internal/kube-proxy.log
ip-10-248-128-35.us-west-2.compute.internal/kube-scheduler.log
ip-10-248-128-35.us-west-2.compute.internal/kubelet.log
```

